### PR TITLE
Smartplug and Smart camera overview URL:s changed to comply with the Verisure web site 

### DIFF
--- a/verisure/devices/smartcam.py
+++ b/verisure/devices/smartcam.py
@@ -5,7 +5,7 @@ Smartcam device
 
 from .overview import Overview
 
-OVERVIEW_URL = '/overview/smartcam'
+OVERVIEW_URL = '/overview/camera'
 
 
 class Smartcam(object):

--- a/verisure/devices/smartplug.py
+++ b/verisure/devices/smartplug.py
@@ -5,7 +5,7 @@ import time
 
 from .overview import Overview
 
-OVERVIEW_URL = '/overview/smartplug'
+OVERVIEW_URL = '/settings/smartplug'
 COMMAND_URL = '/smartplugs/onoffplug.cmd'
 DETAILS_URL = '/smarthome/{}/details'
 


### PR DESCRIPTION
I hade a look at the code so see if I could find a solution to the issue i reported in home assistant (https://github.com/home-assistant/home-assistant/issues/1879). As far as I can tell the overview URL:s for the smart camera and the smart plug has changed on the site. I have fixed it in this pull request.

