### PR TITLE
Cookie caching for speed and security

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This software is not affiliated with Verisure Holding AB and the developers take
 
 ### Version History
 ```
+1.4.1 Add cookie cache for increased speed and to avoid having the password stored on disk
 1.4.0 Add test ethernet command
 1.3.8 Fix vacation mode URL
 1.3.7 Urlencode username
@@ -33,7 +34,7 @@ or
 ## Command line usage
 
 ```
-usage: verisure.py [-h] [-i INSTALLATION]
+usage: verisure.py [-h] [-i INSTALLATION] [-c COOKIE]
                    username password
                    {installations,overview,set,history,eventlog,capture,imageseries,getimage}
                    ...
@@ -62,6 +63,9 @@ optional arguments:
   -h, --help            show this help message and exit
   -i INSTALLATION, --installation INSTALLATION
                         Installation number
+  -c COOKIE, --cookie COOKIE
+                           File to store cookie in
+
 ```
 
 ### Read alarm status

--- a/verisure/__main__.py
+++ b/verisure/__main__.py
@@ -47,6 +47,10 @@ def main():
         help='Installation number',
         type=int,
         default=1)
+    parser.add_argument(
+        '-c', '--cookie',
+        help='File to store cookie in',
+        default='~/.verisure-cookie')
 
     commandsparser = parser.add_subparsers(
         help='commands',
@@ -206,7 +210,7 @@ def main():
         help='Update ethernet status')
 
     args = parser.parse_args()
-    session = verisure.Session(args.username, args.password)
+    session = verisure.Session(args.username, args.password, args.cookie)
     session.login()
     try:
         session.set_giid(session.installations[args.installation - 1]['giid'])
@@ -255,8 +259,6 @@ def main():
             session.test_ethernet()
     except verisure.session.ResponseError as ex:
         print(ex.text)
-    finally:
-        session.logout()
 
 
 # pylint: disable=C0103

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -6,6 +6,7 @@ import base64
 import json
 import requests
 from . import urls
+import os
 
 
 def _validate_response(response):
@@ -51,9 +52,10 @@ class Session(object):
 
     """
 
-    def __init__(self, username, password):
+    def __init__(self, username, password, cookieFileName = '~/.verisure-cookie'):
         self._username = username
         self._password = password
+        self._cookieFileName = os.path.expanduser(cookieFileName)
         self._vid = None
         self._giid = None
         self.installations = None
@@ -64,6 +66,28 @@ class Session(object):
         Login before calling any read or write commands
 
         """
+        if os.path.exists(self._cookieFileName) :
+            with open(self._cookieFileName, 'r') as cookieFile:
+                self._vid = cookieFile.read().strip()
+
+            try:
+                self._get_installations()
+            except ResponseError as ex:
+                self._vid = None
+                print("Invalid cookie; will remove its file")
+                os.remove(self._cookieFileName);
+
+
+        if self._vid is None:
+            self._create_cookie()
+            with open(self._cookieFileName, 'w') as cookieFile:
+                print("Storing cookie in file: " + self._cookieFileName)
+                cookieFile.write(self._vid)
+            self._get_installations()
+
+        self._giid = self.installations[0]['giid']
+
+    def _create_cookie(self):
         auth = 'Basic {}'.format(
             base64.b64encode(
                 'CPE/{username}:{password}'.format(
@@ -81,28 +105,39 @@ class Session(object):
                         'Accept': 'application/json,'
                                   'text/javascript, */*; q=0.01',
                     })
-                _validate_response(response)
-                break
-            except ResponseError as ex:
-                pass
+                if 2 == response.status_code // 100:
+                    break
+                elif 503 == response.status_code:
+                    continue;
+                else:
+                    raise ResponseError(response.status_code, response.text)
             except requests.exceptions.RequestException as ex:
                 raise LoginError(ex)
+
+        _validate_response(response)
         self._vid = json.loads(response.text)['cookie']
-        self._get_installations()
-        self._giid = self.installations[0]['giid']
 
     def _get_installations(self):
         """ Get information about installations """
         response = None
-        try:
-            response = requests.get(
-                urls.get_installations(self._username),
-                headers={
-                    'Cookie': 'vid={}'.format(self._vid),
-                    'Accept': 'application/json, text/javascript, */*; q=0.01',
-                })
-        except requests.exceptions.RequestException as ex:
-            raise RequestError(ex)
+        for base_url in urls.BASE_URLS:
+            urls.BASE_URL = base_url
+            try:
+                response = requests.get(
+                    urls.get_installations(self._username),
+                    headers={
+                        'Cookie': 'vid={}'.format(self._vid),
+                        'Accept': 'application/json, text/javascript, */*; q=0.01',
+                    })
+                if 2 == response.status_code // 100:
+                    break
+                elif 503 == response.status_code:
+                    continue;
+                else:
+                    raise ResponseError(response.status_code, response.text)
+            except requests.exceptions.RequestException as ex:
+                raise RequestError(ex)
+
         _validate_response(response)
         self.installations = json.loads(response.text)
 

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -53,7 +53,7 @@ class Session(object):
     """
 
     def __init__(self, username, password,
-                 cookieFileName = '~/.verisure-cookie'):
+                 cookieFileName='~/.verisure-cookie'):
         self._username = username
         self._password = password
         self._cookieFileName = os.path.expanduser(cookieFileName)
@@ -73,7 +73,7 @@ class Session(object):
 
             try:
                 self._get_installations()
-            except ResponseError as ex:
+            except ResponseError:
                 self._vid = None
                 os.remove(self._cookieFileName)
 

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -52,7 +52,8 @@ class Session(object):
 
     """
 
-    def __init__(self, username, password, cookieFileName = '~/.verisure-cookie'):
+    def __init__(self, username, password,
+                 cookieFileName = '~/.verisure-cookie'):
         self._username = username
         self._password = password
         self._cookieFileName = os.path.expanduser(cookieFileName)
@@ -66,7 +67,7 @@ class Session(object):
         Login before calling any read or write commands
 
         """
-        if os.path.exists(self._cookieFileName) :
+        if os.path.exists(self._cookieFileName):
             with open(self._cookieFileName, 'r') as cookieFile:
                 self._vid = cookieFile.read().strip()
 
@@ -74,14 +75,11 @@ class Session(object):
                 self._get_installations()
             except ResponseError as ex:
                 self._vid = None
-                print("Invalid cookie; will remove its file")
-                os.remove(self._cookieFileName);
-
+                os.remove(self._cookieFileName)
 
         if self._vid is None:
             self._create_cookie()
             with open(self._cookieFileName, 'w') as cookieFile:
-                print("Storing cookie in file: " + self._cookieFileName)
                 cookieFile.write(self._vid)
             self._get_installations()
 
@@ -108,7 +106,7 @@ class Session(object):
                 if 2 == response.status_code // 100:
                     break
                 elif 503 == response.status_code:
-                    continue;
+                    continue
                 else:
                     raise ResponseError(response.status_code, response.text)
             except requests.exceptions.RequestException as ex:
@@ -127,12 +125,13 @@ class Session(object):
                     urls.get_installations(self._username),
                     headers={
                         'Cookie': 'vid={}'.format(self._vid),
-                        'Accept': 'application/json, text/javascript, */*; q=0.01',
+                        'Accept': 'application/json,'
+                                  'text/javascript, */*; q=0.01',
                     })
                 if 2 == response.status_code // 100:
                     break
                 elif 503 == response.status_code:
-                    continue;
+                    continue
                 else:
                     raise ResponseError(response.status_code, response.text)
             except requests.exceptions.RequestException as ex:


### PR DESCRIPTION
Reasons for this change:
* It's a more secure solution. The password does not have to be stored on disk when the cookie has been generated
* Reusing the cookie makes the calls faster. The call to create the cookie is quite slow, so avoiding it saves around 1 second of execution time.