### PR TITLE
Fix wrong string formatting in urls.imagecapture

### DIFF
--- a/verisure/urls.py
+++ b/verisure/urls.py
@@ -93,7 +93,8 @@ def lockconfig(guid, device_label):
 
 def imagecapture(guid, device_label):
     return (installation(guid) +
-            'device/{device_label}/customerimagecamera/imagecapture')
+            'device/{device_label}/customerimagecamera/imagecapture'.format(
+                device_label=device_label))
 
 
 def get_imageseries(guid):


### PR DESCRIPTION
The imagecapture function was missing the format() definition, meaning the urls generated included a literal '{device_label}' instead of the properly formatted one.