### PR TITLE
Raise on login error, after all attempts are exhausted

### DIFF
--- a/verisure/session.py
+++ b/verisure/session.py
@@ -91,6 +91,7 @@ class Session(object):
             self._request_cookies = None
 
         # The login with stored cookies failed, try to get a new one
+        last_exception = None
         for login_url in ['https://automation01.verisure.com/auth/login',
                           'https://automation02.verisure.com/auth/login']:
             try:
@@ -103,11 +104,13 @@ class Session(object):
                     pickle.dump(response.cookies, f)
                 self._request_cookies = {'vid': response.cookies['vid']}
                 self._get_installations()
+                return
             except requests.exceptions.RequestException as ex:
                 raise LoginError(ex)
             except Exception as ex:
-                print(ex)
-                pass
+                last_exception = ex
+
+        raise LoginError(last_exception)
 
     def _get_installations(self):
         """ Get information about installations """


### PR DESCRIPTION
In PR #125, automatic login with multiple login attempts was introduced. However, due to this regression, any error raised is suppressed.

This causes applications using this library not to be able to act on authentication failures.

This PR fixes this behavior by:

- Returning directly after a successful login attempt
- Store the last occurred exception
- If the login method reached the end, no successful login was recorded: re-raise the last recorded exception.


Originally needed for <https://github.com/home-assistant/core/pull/47880>, which re-factors the Verisure integration for Home Assistant.