### PR TITLE
Differentiate response errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ devices.
 ## Version History
 
 ```txt
+2.6.3 Differentiate response errors
 2.6.2 Fix request wrapper
 2.6.1 Move to automation subdomain
 2.6.0 Add Get Firmware Version

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='vsure',
-    version='2.6.2',
+    version='2.6.3',
     description='Read and change status of verisure devices through mypages.',
     long_description='A python3 module for reading and changing status of '
     + 'verisure devices through mypages.',

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -5,6 +5,7 @@ Verisure session, using verisure app api
 import json
 import os
 import pickle
+
 import requests
 
 

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -101,9 +101,6 @@ class Session(object):
                 try:
                     response = function(base_url+url, *args, **kwargs)
                     if response.status_code == 200:
-                        if "SYS_00004" in response.text:
-                            self._base_urls.reverse()
-                            continue
                         return response
                     response.raise_for_status()
                 except requests.exceptions.RequestException as ex:

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -101,13 +101,20 @@ class Session(object):
             for base_url in base_urls:
                 try:
                     response = function(base_url+url, *args, **kwargs)
+                    if response.status_code >= 500:
+                        last_exception = ResponseError(response.status_code, response.text)
+                        self._base_urls.reverse()
+                        continue
+                    if response.status_code >= 400:
+                        last_exception = LoginError(response.text)
+                        break
                     if response.status_code == 200:
                         return response
                     response.raise_for_status()
                 except requests.exceptions.RequestException as ex:
-                    last_exception = ex
+                    last_exception = RequestError(str(ex))
                 self._base_urls.reverse()
-            raise Error from last_exception
+            raise last_exception
         return wrapper
 
 

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -110,7 +110,6 @@ class Session(object):
                         break
                     if response.status_code == 200:
                         return response
-                    response.raise_for_status()
                 except requests.exceptions.RequestException as ex:
                     last_exception = RequestError(str(ex))
                 self._base_urls.reverse()


### PR DESCRIPTION
Please review these changes.

request wrapper now differentiates between different types of errors.
- ResponseError in case of 5** resposne
- LoginError in case of 4** response
- RequestError in case of connection issues
- Error("Unknown error") in case of any response <> status_code 200