### PR TITLE
Enable Trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ devices.
 ## Version History
 
 ```txt
+2.6.5 Enable trust
 2.6.4 Handle "SYS_00004" response again (was removed in 2.6.3)
 2.6.3 Differentiate response errors
 2.6.2 Fix request wrapper

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='vsure',
-    version='2.6.4',
+    version='2.6.5',
     description='Read and change status of verisure devices through mypages.',
     long_description='A python3 module for reading and changing status of '
     + 'verisure devices through mypages.',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='vsure',
-    version='2.6.5',
+    version='2.6.6',
     description='Read and change status of verisure devices through mypages.',
     long_description='A python3 module for reading and changing status of '
     + 'verisure devices through mypages.',

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -81,7 +81,6 @@ class Session(object):
         self._cookie_file_name = os.path.expanduser(cookie_file_name)
         self._giid = None
         self._base_url = None
-        self._stepup = None
         self._base_urls = ['https://automation01.verisure.com',
                            'https://automation02.verisure.com']
         self._post = self._wrap_request(requests.post)
@@ -242,7 +241,6 @@ class Session(object):
             self._base_url = None
             self._giid = None
             self._cookies = None
-            self._stepup = None
             if os.path.exists(self._cookie_file_name):
                 os.remove(self._cookie_file_name)
 

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -231,10 +231,13 @@ class Session(object):
         Cookie can last 15 minutes before it needs to be updated.
         """
 
+        cookie_jar = requests.sessions.RequestsCookieJar()
+        cookie_jar['vid'] = self._cookies['vid']
+        cookie_jar['vs-refresh'] = self._cookies['vs-refresh']
         response = self._get(
             url="/auth/token",
             headers={'APPLICATION_ID': 'PS_PYTHON'},
-            cookies=self._cookies)
+            cookies=cookie_jar)
 
         self._cookies.update(response.cookies)
         with open(self._cookie_file_name, 'wb') as cookie_file:

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -185,10 +185,7 @@ class Session(object):
                 'Content-Type': 'application/json'},
             cookies=self._cookies,
             data=json.dumps({"token": code}))
-
         self._cookies = response.cookies
-        with open(self._cookie_file_name, 'wb') as cookie_file:
-            pickle.dump(self._cookies, cookie_file)
 
         trust_response = self._post(
             url="/auth/trust",
@@ -198,6 +195,8 @@ class Session(object):
             },
             cookies=self._cookies)
         self._cookies.update(trust_response.cookies)
+        with open(self._cookie_file_name, 'wb') as cookie_file:
+            pickle.dump(self._cookies, cookie_file)
         self._trust_token = trust_response.json()
 
         installations = self.get_installations()

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -253,8 +253,10 @@ class Session(object):
         """
 
         cookie_jar = requests.sessions.RequestsCookieJar()
-        cookie_jar['vid'] = self._cookies['vid']
-        cookie_jar['vs-refresh'] = self._cookies['vs-refresh']
+        if self._cookies is not None:
+            for name, value in self._cookies.items():
+                if name in ['vid', 'vs-refresh']:
+                    cookie_jar[name] = value
         response = self._get(
             url="/auth/token",
             headers={'APPLICATION_ID': 'PS_PYTHON'},

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -218,8 +218,16 @@ class Session(object):
         except Exception as ex:
             raise LoginError("Failed to read cookie") from ex
 
-        # Update cookie
-        self.update_cookie()
+        # Login
+        response = self._post(
+            "/auth/login",
+            headers={
+                'APPLICATION_ID': 'PS_PYTHON',
+                'Accept': 'application/json',
+            },
+            auth=(self._username, self._password),
+            cookies=self._cookies)
+        self._cookies.update(response.cookies)
 
         installations = self.get_installations()
         if 'errors' not in installations:

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -217,8 +217,19 @@ class Session(object):
         except Exception as ex:
             raise LoginError("Failed to read cookie") from ex
 
-        # Update cookie
-        self.update_cookie()
+        # Login
+        cookie_jar = requests.sessions.RequestsCookieJar()
+        for name, value in self._cookies.items():
+            if 'vs-trust' in name:
+                cookie_jar.set(name, value)
+        response = self._post(
+            url="/auth/login",
+            headers={'APPLICATION_ID': 'PS_PYTHON'},
+            auth=(self._username, self._password),
+            cookies=cookie_jar)
+        self._cookies.update(response.cookies)
+        with open(self._cookie_file_name, 'wb') as f:
+            pickle.dump(self._cookies, f)
 
         installations = self.get_installations()
         if 'errors' not in installations:

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -217,16 +217,8 @@ class Session(object):
         except Exception as ex:
             raise LoginError("Failed to read cookie") from ex
 
-        # Login
-        response = self._post(
-            "/auth/login",
-            headers={
-                'APPLICATION_ID': 'PS_PYTHON',
-                'Accept': 'application/json',
-            },
-            auth=(self._username, self._password),
-            cookies=self._cookies)
-        self._cookies.update(response.cookies)
+        # Update cookie
+        self.update_cookie()
 
         installations = self.get_installations()
         if 'errors' not in installations:


### PR DESCRIPTION
Please review and test these changes.

## Changes
- Removed `_stepup` variable as it was not being used anywhere
- Add trust request to `validate_mfa` method and update cookies accordingly
- Add login request to `login_cookie` method to attempt login with the trust cookie
- Add untrust request to `logout` method to remove trust between server and the local instance