### PR TITLE
Fix empty cookie jar on token refresh by hydrating from disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ devices.
 ## Version History
 
 ```txt
+2.6.9 Load cookie file before token refresh when in-memory jars are empty
 2.6.8 Added prompt for password
 2.6.7 Add logging option for CLI, do not send empty requests
 2.6.6 Enable trust

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='vsure',
-    version='2.6.8',
+    version='2.6.9',
     description='Read and change status of verisure devices through mypages.',
     long_description='A python3 module for reading and changing status of '
     + 'verisure devices through mypages.',

--- a/verisure/__init__.py
+++ b/verisure/__init__.py
@@ -6,6 +6,7 @@ verisure app API.
 __all__ = [
     'Error',
     'LoginError',
+    'RequestError',
     'ResponseError',
     'Session',
 ]
@@ -13,6 +14,7 @@ __all__ = [
 from .session import ( # NOQA
     Error,
     LoginError,
+    RequestError,
     VariableTypes,
     ResponseError,
     Session,

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -215,17 +215,23 @@ class Session(object):
 
         raise LoginError("Failed to log in")
 
+    def _load_cookie_file_into_memory(self):
+        """Populate ``_cookies`` from the persisted pickle (used by cookie login paths)."""
+
+        try:
+            with open(self._cookie_file_name, 'rb') as cookie_file:
+                self._cookies = pickle.load(cookie_file)
+        except OSError as ex:
+            raise LoginError("Failed to read cookie") from ex
+        except (EOFError, pickle.UnpicklingError, AttributeError, TypeError, ValueError) as ex:
+            raise LoginError("Failed to read cookie") from ex
+
     def login_cookie(self):
         """ Login using cookie
         Return installations
         """
 
-        # Load cookie from file
-        try:
-            with open(self._cookie_file_name, 'rb') as cookie_file:
-                self._cookies = pickle.load(cookie_file)
-        except Exception as ex:
-            raise LoginError("Failed to read cookie") from ex
+        self._load_cookie_file_into_memory()
 
         # Login
         cookie_jar = requests.sessions.RequestsCookieJar()
@@ -250,7 +256,13 @@ class Session(object):
     def update_cookie(self):
         """ Update expired cookie
         Cookie can last 15 minutes before it needs to be updated.
+
+        Long-running callers may reset ``self._cookies`` while a valid pickle remains
+        on disk; hydrate from the file before calling ``/auth/token`` so the request
+        is not sent with an empty cookie jar.
         """
+        if self._cookies is None:
+            self._load_cookie_file_into_memory()
 
         cookie_jar = requests.sessions.RequestsCookieJar()
         if self._cookies is not None:


### PR DESCRIPTION
Long-running sessions could reset the in-memory cookie jar between calls, causing /auth/token requests to be sent with no cookies and fail. Reload the persisted cookie pickle in update_cookie when the in-memory jar is empty, and extract the load logic into a shared helper so login_cookie reuses it.