### PR TITLE
Reuse MFA login cookies and classify step-up rate limits (2.7.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ devices.
 ## Version History
 
 ```txt
+2.7.1 Reuse MFA login cookies to avoid duplicate /auth/login, classify ACC_00002 step-up rate limits as RateLimitError
 2.7.0 Structured session errors (AuthenticationError, CookieReadError, RateLimitError), HTTP status on exceptions, update_cookie retries
 2.6.9 Load cookie file before token refresh when in-memory jars are empty
 2.6.8 Added prompt for password

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='vsure',
-    version='2.7.0',
+    version='2.7.1',
     description='Read and change status of verisure devices through mypages.',
     long_description='A python3 module for reading and changing status of '
     + 'verisure devices through mypages.',

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -55,11 +55,19 @@ class ResponseError(Error):
             f'Invalid response, status code: {status_code} - Data: {text}')
 
 
+MFA_REQUIRED_MESSAGE = (
+    'Multifactor authentication enabled, disable or create MFA cookie'
+)
+
+
 def _response_signals_rate_limit(text: str) -> bool:
     """Return True when the API rejected the call for rate or quota limits."""
     lower = text.lower()
     return (
         'aut_00021' in lower
+        or 'acc_00002' in lower
+        or 'toomanystepuptokens' in lower
+        or 'too many step up tokens' in lower
         or 'request limit' in lower
         or 'rate limit' in lower
         or 'too many requests' in lower
@@ -68,10 +76,10 @@ def _response_signals_rate_limit(text: str) -> bool:
 
 def _http_error_from_response(status_code: int, text: str) -> Error:
     """Map an HTTP error response to a structured Verisure exception."""
-    if status_code in (401, 403):
-        return AuthenticationError(text, status_code=status_code)
     if status_code == 429 or _response_signals_rate_limit(text):
         return RateLimitError(text)
+    if status_code in (401, 403):
+        return AuthenticationError(text, status_code=status_code)
     if status_code >= 500:
         return ResponseError(status_code, text)
     return LoginError(text, status_code=status_code)
@@ -126,6 +134,7 @@ class Session(object):
         self._cookies = None
         self._cookie_file_name = os.path.expanduser(cookie_file_name)
         self._trust_token = None
+        self._mfa_login_pending = False
         self._giid = None
         self._base_url = None
         self._base_urls = ['https://automation01.verisure.com',
@@ -189,9 +198,11 @@ class Session(object):
             auth=(self._username, self._password))
 
         if "stepUpToken" in response.text:
-            raise LoginError("Multifactor authentication enabled, "
-                             "disable or create MFA cookie")
+            self._cookies = response.cookies
+            self._mfa_login_pending = True
+            raise LoginError(MFA_REQUIRED_MESSAGE)
 
+        self._mfa_login_pending = False
         self._cookies = response.cookies
         with open(self._cookie_file_name, 'wb') as f:
             pickle.dump(self._cookies, f)
@@ -205,16 +216,20 @@ class Session(object):
     def request_mfa(self):
         """ Request MFA verification code """
 
-        response = self._post(
-            url="/auth/login",
-            headers={'APPLICATION_ID': 'PS_PYTHON'},
-            auth=(self._username, self._password))
+        if not self._mfa_login_pending:
+            response = self._post(
+                url="/auth/login",
+                headers={'APPLICATION_ID': 'PS_PYTHON'},
+                auth=(self._username, self._password))
 
-        if "stepUpToken" not in response.text:
-            raise LoginError("Multifactor authentication disabled, "
-                             "use regular login instead")
+            if "stepUpToken" not in response.text:
+                raise LoginError("Multifactor authentication disabled, "
+                                 "use regular login instead")
 
-        self._cookies = response.cookies
+            self._cookies = response.cookies
+            self._mfa_login_pending = True
+
+        self._mfa_login_pending = False
         for mfa_type in ['phone', 'email']:
             try:
                 mfa_response = self._post(
@@ -372,6 +387,7 @@ class Session(object):
             self._giid = None
             self._cookies = None
             self._trust_token = None
+            self._mfa_login_pending = False
             if os.path.exists(self._cookie_file_name):
                 os.remove(self._cookie_file_name)
 


### PR DESCRIPTION
## Summary

Fixes MFA login flows that hammer Verisure's `/auth/login` endpoint and trigger `ACC_00002` ("Too many step up tokens sent").

When MFA is required, `login()` raised before saving cookies, so `request_mfa()` posted to `/auth/login` again. Integrations that call both (e.g. Home Assistant config flow) could send duplicate step-up tokens and hit Verisure rate limits.

## Changes

- **`login()`**: when the response contains `stepUpToken`, persist `response.cookies` in memory and set `_mfa_login_pending` before raising the MFA-required error.
- **`request_mfa()`**: skip the second `/auth/login` POST when `_mfa_login_pending` is already set; proceed directly to `/auth/mfa?type=…`.
- **Rate limits**: classify `ACC_00002` / `tooManyStepUpTokens` as `RateLimitError` (checked before mapping 401 to `AuthenticationError`), so callers can back off instead of treating it as invalid credentials.
- **Version**: bump to `2.7.1`.

## Related

- Home Assistant: home-assistant/core#171317 (session handling; blocked on this release)
- Builds on #182 (2.7.0 structured session errors)