### PR TITLE
Add force_arm option to arm_away and arm_home

### DIFF
--- a/verisure/session.py
+++ b/verisure/session.py
@@ -421,29 +421,33 @@ class Session(object):
     @query_func
     def arm_away(self,
                  code: VariableTypes.Code,
-                 giid: VariableTypes.Giid=None):
+                 giid: VariableTypes.Giid=None,
+                 force_arm: bool=False):
         """Set arm status away"""
         assert giid or self._giid, "Set default giid or pass explicit"
         return {
             "operationName": "armAway",
             "variables": {
                 "giid": giid or self._giid,
-                "code": code},
-            "query": "mutation armAway($giid: String!, $code: String!) {\n  armStateArmAway(giid: $giid, code: $code)\n}\n",  # noqa: E501
+                "code": code,
+                "forceArm": force_arm},
+            "query": "mutation armAway($giid: String!, $code: String!, $forceArm: Boolean) {\n  armStateArmAway(giid: $giid, code: $code, forceArm: $forceArm)\n}\n",  # noqa: E501
         }
 
     @query_func
     def arm_home(self,
                  code: VariableTypes.Code,
-                 giid: VariableTypes.Giid=None):
+                 giid: VariableTypes.Giid=None,
+                 force_arm: bool=False):
         """Set arm state home"""
         assert giid or self._giid, "Set default giid or pass explicit"
         return {
             "operationName": "armHome",
             "variables": {
                 "giid": giid or self._giid,
-                "code": code},
-            "query": "mutation armHome($giid: String!, $code: String!) {\n  armStateArmHome(giid: $giid, code: $code)\n}\n",  # noqa: E501
+                "code": code,
+                "forceArm": force_arm},
+            "query": "mutation armHome($giid: String!, $code: String!, $forceArm: Boolean) {\n  armStateArmHome(giid: $giid, code: $code, forceArm: $forceArm)\n}\n",  # noqa: E501
         }
 
     @query_func


### PR DESCRIPTION
## Summary

Adds an optional `force_arm` parameter (default `False`) to `Session.arm_away()`
and `Session.arm_home()`. When `True`, the generated mutation sends
`forceArm: true`, arming the alarm even when a device is "out of place" /
reporting a problem — the same behaviour as the **Arm anyway** button in the
My Verisure app.

## Why

Without this, arming through the API stalls indefinitely whenever the
installation has a device that can't be restored: the backend never confirms the
arm (the arm-state poll never returns `OK`) because it's waiting for an explicit
override the library can't send. The Verisure app surfaces this as an "Arm anyway" prompt.

## What changed

`arm_away` / `arm_home` now build, e.g.:

    mutation armAway($giid: String!, $code: String!, $forceArm: Boolean) {
      armStateArmAway(giid: $giid, code: $code, forceArm: $forceArm)
    }

with `forceArm` added to the variables. `disarm` is untouched.

## API evidence

Captured from real My Verisure web traffic (mypages.verisure.com), values redacted:

    armAway → {"operationName":"armAway","variables":{"giid":"…","code":"…","forceArm":true},
    "query":"mutation armAway($giid: String!, $code: String!, $forceArm: Boolean) {\n  armStateArmAway(giid: $giid, code: $code, forceArm: $forceArm)\n}"}

    armHome → {"operationName":"armHome","variables":{"giid":"…","code":"…","forceArm":true},
    "query":"mutation armHome($giid: String!, $code: String!, $forceArm: Boolean) {\n  armStateArmHome(giid: $giid, code: $code, forceArm: $forceArm)\n}"}

## Backwards compatibility

`force_arm` defaults to `False`, so existing callers are unaffected. `$forceArm`
is an optional `Boolean`; sending `false` behaves like a normal arm.

## Follow-up

Enables a "Force arm" option in the Home Assistant Verisure integration
(separate PR to home-assistant/core, pending a release that includes this).