### PR TITLE
Add arm state dry run methods

### DIFF
--- a/verisure/session.py
+++ b/verisure/session.py
@@ -473,6 +473,32 @@ class Session(object):
         }
 
     @query_func
+    def arm_state_dry_run(self,
+                          giid: Optional[VariableTypes.Giid] = None) -> Dict[str, object]:
+        """Start an arm state dry run to check if arming requires force"""
+        resolved_giid = self._resolve_giid(giid)
+        return {
+            "operationName": "ArmStateDryRun",
+            "variables": {
+                "giid": resolved_giid},
+            "query": "mutation ArmStateDryRun($giid: String!) {\n  armStateDryRun(giid: $giid)\n}\n",  # noqa: E501
+        }
+
+    @query_func
+    def arm_state_dry_run_status(self,
+                                 transaction_id: VariableTypes.TransactionId,
+                                 giid: Optional[VariableTypes.Giid] = None) -> Dict[str, object]:
+        """Poll the status of an arm state dry run"""
+        resolved_giid = self._resolve_giid(giid)
+        return {
+            "operationName": "ArmStateDryRunStatus",
+            "variables": {
+                "giid": resolved_giid,
+                "transactionId": transaction_id},
+            "query": "query ArmStateDryRunStatus($giid: String!, $transactionId: String!) {\n  installation(giid: $giid) {\n    armState {\n      dryRunStatus(transactionId: $transactionId) {\n        status {\n          status\n          createTime\n          changeTime\n          __typename\n        }\n        result {\n          created\n          received\n          deviceViolations {\n            deviceLabel\n            violation\n            occurred\n            __typename\n          }\n          __typename\n        }\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n",  # noqa: E501
+        }
+
+    @query_func
     def broadband(self,
                   giid: Optional[VariableTypes.Giid] = None) -> Dict[str, object]:
         """Get broadband status"""


### PR DESCRIPTION
## Summary

Adds two methods for the arm-state "dry run", which checks whether arming would require forcing past out-of-place devices:

- `arm_state_dry_run(giid)` starts a dry run and returns a transaction id.
- `arm_state_dry_run_status(transaction_id, giid)` polls the dry run and returns `result.deviceViolations`, a list of `{ deviceLabel, violation }` (for example `violation: DOOR_WINDOW_OPEN`). Empty means arming would proceed cleanly; non-empty means it would need to force.

## Why

This exposes a "would require force / device out of place" readiness signal, needed for a binary sensor in the Home Assistant Verisure integration. It is a follow-up to the `force_arm` work in #185.

## API evidence

Captured from the My Verisure web portal (mypages.verisure.com). The mutation and query mirror what the web app uses when deciding whether to show the "Arm anyway" prompt.